### PR TITLE
Added string route path support

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -1,4 +1,5 @@
 class Router {
+  
   routes = [];
 
   mode = null;
@@ -13,6 +14,7 @@ class Router {
   }
 
   add = (path, cb) => {
+    path = path ? new RegExp(this.clearSlashes(path)) : ''
     this.routes.push({ path, cb });
     return this;
   };
@@ -79,6 +81,7 @@ class Router {
       return false;
     });
   };
+
 }
 
 export default Router;

--- a/src/index.html
+++ b/src/index.html
@@ -7,6 +7,7 @@
     <li><a href="/#/about">About page</a></li>
     <li><a href="/#/products/12/specification/10">Go to the product 12</a></li>
     <li><a href="/#/products/22/specification/12">Go to the product 22</a></li>
+    <li><a href="/#/u/johndoe">Get Username</a></li>
   </ul>
 </body>
 </html>

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,9 @@ router
   .add(/products\/(.*)\/specification\/(.*)/, (id, specification) => {
     alert(`products: ${id} specification: ${specification}`);
   })
+  .add('/u/(.*)', (username) => {
+    alert(`username: ${username}`)
+  })
   .add('', () => {
     // general controller
     console.log('welcome in catch all controller');


### PR DESCRIPTION
Allow to use string as path for routes in case you won't use regex, and i think this more simple than escaping each backslash in path.

Example:

``` js
[...]

router
  .add('/products/(.*)/specification/(.*)', (id, specification) => {
    alert(`products: ${id} specification: ${specification}`)
  })
[...]
```